### PR TITLE
Adding support to compile with destination 'Apple Vision Pro'

### DIFF
--- a/Sources/GeodesySpherical/Coordinate.swift
+++ b/Sources/GeodesySpherical/Coordinate.swift
@@ -6,7 +6,7 @@
 //
 //
 
-#if os(OSX) || os(iOS)
+#if os(OSX) || os(iOS) || os(visionOS)
     import Darwin
 #elseif os(Linux)
     import Glibc


### PR DESCRIPTION
fixes issue #4 

How to reproduce the issue: Compile in Xcode with destination 'Apple Vision Pro'.

Fixed by importing Darwin also in case of visionOS.

Tested that package compiles with destination 'Apple Vision Pro' after making this fix.
